### PR TITLE
Moved Equatable implementation to test file

### DIFF
--- a/SerpentComparisonTests/PerformanceTestSmallModel.swift
+++ b/SerpentComparisonTests/PerformanceTestSmallModel.swift
@@ -18,12 +18,6 @@ struct PerformanceTestSmallModel {
 	var name = ""
 }
 
-extension PerformanceTestSmallModel : Equatable {
-    static func ==(lhs: PerformanceTestSmallModel, rhs: PerformanceTestSmallModel) -> Bool {
-        return lhs.id == rhs.id && lhs.name == rhs.name
-    }
-}
-
 
 // Serpent
 extension PerformanceTestSmallModel: Serializable {

--- a/SerpentComparisonTests/SerpentComparisonTests.swift
+++ b/SerpentComparisonTests/SerpentComparisonTests.swift
@@ -13,6 +13,12 @@ import ObjectMapper
 import Serpent
 @testable import SerpentComparison
 
+extension PerformanceTestSmallModel : Equatable {
+    static func ==(lhs: PerformanceTestSmallModel, rhs: PerformanceTestSmallModel) -> Bool {
+        return lhs.id == rhs.id && lhs.name == rhs.name
+    }
+}
+
 class SerpentComparisonTests: XCTestCase {
     
     var largeData: NSData!


### PR DESCRIPTION
In theory, we shouldn't implement an Equatable protocol only for testing purposes in the main project. It wasn't a particular problem for this project, but it's more correct to have it in the test file