### PR TITLE
Improve error detection and reduce casting

### DIFF
--- a/SerpentComparisonTests/SerpentComparisonTests.swift
+++ b/SerpentComparisonTests/SerpentComparisonTests.swift
@@ -91,7 +91,7 @@ class SerpentComparisonTests: XCTestCase {
             
         }
         catch {
-            print(error)
+            XCTFail(error.localizedDescription)
         }
         
         
@@ -104,7 +104,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ = PerformanceTestModel.array(jsonDict["data"])
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -116,7 +116,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ = PerformanceTestSmallModel.array(smallJsonDict["data"])
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -128,7 +128,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ = try freddyDict.getArray(at: "data").map(PerformanceTestModel.init)
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -140,7 +140,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ = try smallFreddyDict.getArray(at: "data").map(PerformanceTestSmallModel.init)
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -154,7 +154,7 @@ class SerpentComparisonTests: XCTestCase {
                 }
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -168,7 +168,7 @@ class SerpentComparisonTests: XCTestCase {
                 }
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -180,7 +180,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ = Mapper<PerformanceTestModel>().mapArray(JSONObject: (objectMapperDict["data"]))
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -192,7 +192,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ = Mapper<PerformanceTestSmallModel>().mapArray(JSONObject: objectMapperSmallDict["data"])
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -204,7 +204,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ = try Array<PerformanceTestModel>(JSONArray: jsonCodableDict["data"] as! [[String: AnyObject]])
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -217,7 +217,7 @@ class SerpentComparisonTests: XCTestCase {
                 
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -229,7 +229,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ : [PerformanceTestModel] = try unbox(dictionaries: unboxDict["data"] as! [[String : AnyObject]])
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -242,7 +242,7 @@ class SerpentComparisonTests: XCTestCase {
                 
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -254,7 +254,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ : [PerformanceTestModel] = try [PerformanceTestModel].decode(decodableDict["data"] as! [[String : AnyObject]])
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -267,7 +267,7 @@ class SerpentComparisonTests: XCTestCase {
                 
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -279,7 +279,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ : [PerformanceTestModel] = try marshalDict.value(for: "data")
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }
@@ -291,7 +291,7 @@ class SerpentComparisonTests: XCTestCase {
                 let _ : [PerformanceTestSmallModel] = try smallMarshalDict.value(for: "data")
             }
             catch {
-                print(error)
+                XCTFail(error.localizedDescription)
             }
         }
     }

--- a/SerpentComparisonTests/SerpentComparisonTests.swift
+++ b/SerpentComparisonTests/SerpentComparisonTests.swift
@@ -24,15 +24,19 @@ extension PerformanceTestSmallModel : Equatable {
 
 class SerpentComparisonTests: XCTestCase {
     
-    var largeData: NSData!
-    var smallData: NSData!
+    var largeData: Data!
+    var smallData: Data!
     
     override func setUp() {
         super.setUp()
-        if let path = Bundle(for: type(of: self)).path(forResource: "PerformanceTest", ofType: "json"), let data = NSData(contentsOfFile: path) {
+
+        let bundle = Bundle(for: type(of: self))
+        if let path = bundle.url(forResource: "PerformanceTest", withExtension: "json"),
+            let data = try? Data(contentsOf: path) {
             largeData = data
         }
-        if let path = Bundle(for: type(of: self)).path(forResource: "PerformanceSmallTest", ofType: "json"), let data = NSData(contentsOfFile: path) {
+        if let path = bundle.url(forResource: "PerformanceSmallTest", withExtension: "json"),
+            let data = try? Data(contentsOf: path) {
             smallData = data
         }
     }
@@ -42,13 +46,13 @@ class SerpentComparisonTests: XCTestCase {
         // parse the small model with all the frameworks and test that the resulted struct has the same values and that they're the expected ones
         
         do {
-            let jsonDict = try JSONSerialization.jsonObject(with: self.smallData as Data, options: .allowFragments) as! NSDictionary
+            let jsonDict = try JSONSerialization.jsonObject(with: self.smallData, options: .allowFragments) as! NSDictionary
             
             // serpent
             let serpentParsedModel = PerformanceTestSmallModel.array(jsonDict["data"])
             
             // freddy
-            let smallFreddyDict = try Freddy.JSON(data: smallData as Data)
+            let smallFreddyDict = try Freddy.JSON(data: smallData)
             let freddyParsedModel = try smallFreddyDict.getArray(at: "data").map(PerformanceTestSmallModel.init)
             
             // gloss
@@ -100,7 +104,7 @@ class SerpentComparisonTests: XCTestCase {
     func testSerpentBig() {
         self.measure { () -> Void in
             do {
-                let jsonDict = try JSONSerialization.jsonObject(with: self.largeData as Data, options: .allowFragments) as! NSDictionary
+                let jsonDict = try JSONSerialization.jsonObject(with: self.largeData, options: .allowFragments) as! NSDictionary
                 let _ = PerformanceTestModel.array(jsonDict["data"])
             }
             catch {
@@ -112,7 +116,7 @@ class SerpentComparisonTests: XCTestCase {
     func testSerpentSmall() {
         self.measure {
             do {
-                let smallJsonDict = try JSONSerialization.jsonObject(with: self.smallData as Data, options: .allowFragments) as! NSDictionary
+                let smallJsonDict = try JSONSerialization.jsonObject(with: self.smallData, options: .allowFragments) as! NSDictionary
                 let _ = PerformanceTestSmallModel.array(smallJsonDict["data"])
             }
             catch {
@@ -124,7 +128,7 @@ class SerpentComparisonTests: XCTestCase {
     func testFreddyBig() {
         self.measure {
             do {
-                let freddyDict = try Freddy.JSON(data: self.largeData as Data)
+                let freddyDict = try Freddy.JSON(data: self.largeData)
                 let _ = try freddyDict.getArray(at: "data").map(PerformanceTestModel.init)
             }
             catch {
@@ -136,7 +140,7 @@ class SerpentComparisonTests: XCTestCase {
     func testFreddySmall() {
         self.measure {
             do {
-                let smallFreddyDict = try Freddy.JSON(data: self.smallData as Data)
+                let smallFreddyDict = try Freddy.JSON(data: self.smallData)
                 let _ = try smallFreddyDict.getArray(at: "data").map(PerformanceTestSmallModel.init)
             }
             catch {
@@ -148,7 +152,7 @@ class SerpentComparisonTests: XCTestCase {
     func testGlossBig() {
         self.measure {
             do {
-                let glossDict = try JSONSerialization.jsonObject(with: self.largeData as Data, options: .allowFragments) as! Gloss.JSON
+                let glossDict = try JSONSerialization.jsonObject(with: self.largeData, options: .allowFragments) as! Gloss.JSON
                 if let objects = glossDict["data"] as? [Gloss.JSON] {
                     let _ = [PerformanceTestModel].from(jsonArray: objects)
                 }
@@ -162,7 +166,7 @@ class SerpentComparisonTests: XCTestCase {
     func testGlossSmall() {
         self.measure {
             do {
-                let smallGlossDict = try JSONSerialization.jsonObject(with: self.smallData as Data, options: .allowFragments) as! Gloss.JSON
+                let smallGlossDict = try JSONSerialization.jsonObject(with: self.smallData, options: .allowFragments) as! Gloss.JSON
                 if let objects = smallGlossDict["data"] as? [Gloss.JSON] {
                     let _ = [PerformanceTestSmallModel].from(jsonArray: objects)
                 }
@@ -176,7 +180,7 @@ class SerpentComparisonTests: XCTestCase {
     func testObjectMapperBig() {
         self.measure {
             do {
-                let objectMapperDict = try JSONSerialization.jsonObject(with: self.largeData as Data, options: .allowFragments) as! NSDictionary
+                let objectMapperDict = try JSONSerialization.jsonObject(with: self.largeData, options: .allowFragments) as! NSDictionary
                 let _ = Mapper<PerformanceTestModel>().mapArray(JSONObject: (objectMapperDict["data"]))
             }
             catch {
@@ -188,7 +192,7 @@ class SerpentComparisonTests: XCTestCase {
     func testObjectMapperSmall() {
         self.measure {
             do {
-                let objectMapperSmallDict = try JSONSerialization.jsonObject(with: self.smallData as Data, options: .allowFragments) as! NSDictionary
+                let objectMapperSmallDict = try JSONSerialization.jsonObject(with: self.smallData, options: .allowFragments) as! NSDictionary
                 let _ = Mapper<PerformanceTestSmallModel>().mapArray(JSONObject: objectMapperSmallDict["data"])
             }
             catch {
@@ -200,7 +204,7 @@ class SerpentComparisonTests: XCTestCase {
     func testJSONCodableBig() {
         self.measure {
             do {
-                let jsonCodableDict = try JSONSerialization.jsonObject(with: self.largeData as Data, options: .allowFragments) as! [String: AnyObject]
+                let jsonCodableDict = try JSONSerialization.jsonObject(with: self.largeData, options: .allowFragments) as! [String: AnyObject]
                 let _ = try Array<PerformanceTestModel>(JSONArray: jsonCodableDict["data"] as! [[String: AnyObject]])
             }
             catch {
@@ -212,7 +216,7 @@ class SerpentComparisonTests: XCTestCase {
     func testJSONCodableSmall() {
         self.measure {
             do {
-                let jsonCodableSmallDict = try JSONSerialization.jsonObject(with: self.smallData as Data, options: .allowFragments) as! [String: AnyObject]
+                let jsonCodableSmallDict = try JSONSerialization.jsonObject(with: self.smallData, options: .allowFragments) as! [String: AnyObject]
                 let _ = try Array<PerformanceTestSmallModel>(JSONArray: jsonCodableSmallDict["data"] as! [[String: AnyObject]])
                 
             }
@@ -225,7 +229,7 @@ class SerpentComparisonTests: XCTestCase {
     func testUnboxBig() {
         self.measure {
             do {
-                let unboxDict = try JSONSerialization.jsonObject(with: self.largeData as Data, options: .allowFragments) as! [String: AnyObject]
+                let unboxDict = try JSONSerialization.jsonObject(with: self.largeData, options: .allowFragments) as! [String: AnyObject]
                 let _ : [PerformanceTestModel] = try unbox(dictionaries: unboxDict["data"] as! [[String : AnyObject]])
             }
             catch {
@@ -237,7 +241,7 @@ class SerpentComparisonTests: XCTestCase {
     func testUnboxSmall() {
         self.measure {
             do {
-                let unboxSmallDict = try JSONSerialization.jsonObject(with: self.smallData as Data, options: .allowFragments) as! [String: AnyObject]
+                let unboxSmallDict = try JSONSerialization.jsonObject(with: self.smallData, options: .allowFragments) as! [String: AnyObject]
                 let _ : [PerformanceTestSmallModel] = try unbox(dictionaries: unboxSmallDict["data"] as! [[String : AnyObject]])
                 
             }
@@ -250,7 +254,7 @@ class SerpentComparisonTests: XCTestCase {
     func testDecodableBig() {
         self.measure {
             do {
-                let decodableDict = try JSONSerialization.jsonObject(with: self.largeData as Data, options: .allowFragments) as! [String : AnyObject]
+                let decodableDict = try JSONSerialization.jsonObject(with: self.largeData, options: .allowFragments) as! [String : AnyObject]
                 let _ : [PerformanceTestModel] = try [PerformanceTestModel].decode(decodableDict["data"] as! [[String : AnyObject]])
             }
             catch {
@@ -262,7 +266,7 @@ class SerpentComparisonTests: XCTestCase {
     func testDecodableSmall() {
         self.measure {
             do {
-                let decodableSmallDict = try JSONSerialization.jsonObject(with: self.smallData as Data, options: .allowFragments) as! [String: AnyObject]
+                let decodableSmallDict = try JSONSerialization.jsonObject(with: self.smallData, options: .allowFragments) as! [String: AnyObject]
                 let _ : [PerformanceTestSmallModel] = try [PerformanceTestSmallModel].decode(decodableSmallDict["data"] as! [[String : AnyObject]])
                 
             }
@@ -275,7 +279,7 @@ class SerpentComparisonTests: XCTestCase {
     func testMarshalBig() {
         self.measure {
             do {
-                let marshalDict = try Marshal.JSONParser.JSONObjectWithData(self.largeData as Data)
+                let marshalDict = try Marshal.JSONParser.JSONObjectWithData(self.largeData)
                 let _ : [PerformanceTestModel] = try marshalDict.value(for: "data")
             }
             catch {
@@ -287,7 +291,7 @@ class SerpentComparisonTests: XCTestCase {
     func testMarshalSmall() {
         self.measure {
             do {
-                let smallMarshalDict = try Marshal.JSONParser.JSONObjectWithData(self.smallData as Data)
+                let smallMarshalDict = try Marshal.JSONParser.JSONObjectWithData(self.smallData)
                 let _ : [PerformanceTestSmallModel] = try smallMarshalDict.value(for: "data")
             }
             catch {


### PR DESCRIPTION
* Use XCTFail instead of print for try-catch errors
* Decode JSON files as Data instead of NSData

Also, imo `options` should be `[]` instead of `.allowFragments`